### PR TITLE
Add instructions for running nebel to create symbolic links

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -135,3 +135,61 @@ nebel create-from assemblies/installing-on-apache-karaf/as_install-karaf-for-adm
 ----
 +
 After running this command, you should find three new procedure modules under the `modules/installing-on-apache-karaf/` directory.
+
+== Adding symbolic links with Nebel
+
+All content is in the `assemblies` directory and the `modules` directory. For publishing a book, the `master.adoc` file for the book is in another directory, which is a peer to the `assemblies` 
+directory and `modules` directory. To generate the book, you need symbolic links in the book directory to the category directories that contain the assemblies and modules. 
+
+=== Setting up a book directory for symbolic links
+
+In a book directory, before you add symbolic links to category directories, add an `assemblies` directory, an `images` directory, and a `modules` directory. 
+For example, suppose the name of the book directory is `installing-on-jboss-eap`. You want the `installing-on-jboss-eap` directory to contain:
+
+----
+assemblies
+images
+modules
+master-docinfo.xml 
+master.adoc 
+----
+
+=== Running Nebel to add symbolic links
+
+To run nebel to create symbolic links, the command line has the following form:
+
+----
+nebel book book-directory-name -c "category1,category2,...categoryn"
+----
+
+Replace _book-directory-name_ with the name of the directory that contains the book for which you are adding symbolic links to category directories. 
+In the quotation marks, insert the name of each category directory for which you want symbolic links. 
+For example, the following command adds symbolic links to the directory that contains the book,  Installing on JBoss EAP:
+
+----
+nebel book installing-on-jboss-eap -c "installing-on-jboss-eap,maven"
+----
+
+In the `installing-on-jboss-eap/assemblies` directory, the example command adds symbolic links to:
+
+----
+assemblies/installing-on-jboss-eap
+assemblies/maven
+----
+
+In the `installing-on-jboss-eap/modules` directory, the example command adds symbolic links to:
+
+----
+modules/installing-on-jboss-eap
+modules/maven
+----
+
+In the `installing-on-jboss-eap/images` directory, the example command adds symbolic links to:
+
+----
+images/installing-on-jboss-eap
+images/maven
+----
+
+At a later time, if you add a new category in the main `assemblies` directory or in the main `modules` directory, 
+you can run the command again and specify only the new catagory or catagories. 


### PR DESCRIPTION
At the end of the readme, I added instructions for running nebel to create symbolic links. This is ready to merge if you approve.  Of course, feel free to change it or update it in place. 